### PR TITLE
Ah/bug/extended commands defaults

### DIFF
--- a/extended_hotkeys/core.py
+++ b/extended_hotkeys/core.py
@@ -157,7 +157,7 @@ def make_multiple_hotkey_factory(callback_list, timeout=1000, fast_exit=True):
     return multiple_hotkey_manager
 
 
-def addExtendedCommand(menu, name, commands, shortcut=None, icon=None, tooltip="", index=-1, readonly=False, shortcutContext=0, timeout=1000):
+def addExtendedCommand(menu, name, commands, shortcut=None, icon=None, tooltip="", index=-1, readonly=False, shortcutContext=None, timeout=1000):
     """
 addExtendedCommand(...)
     self.addCommand(name, command, shortcut, icon, tooltip, index, readonly) -> The menu/toolbar item that was added to hold the command.
@@ -185,14 +185,24 @@ addExtendedCommand(...)
         output_command = sanitized_commands[0]
     else:
         output_command = make_multiple_hotkey_factory(sanitized_commands, timeout=timeout)
+
+    kwargs = {}
+    if shortcut:
+        kwargs["shortcut"] = shortcut
+    if icon:
+        kwargs["icon"] = icon
+    if tooltip:
+        kwargs["tooltip"] = tooltip
+    if index != -1:
+        kwargs["index"] = index
+    if readonly is not False:
+        kwargs["readonly"] = readonly
+    if shortcutContext is not None:
+        kwargs["shortcutContext"] = shortcutContext
+
     return menu.addCommand(
         name,
         output_command,
-        shortcut=shortcut,
-        icon=icon,
-        tooltip=tooltip,
-        index=index,
-        readonly=readonly,
-        shortcutContext=shortcutContext
+        **kwargs
     )
 

--- a/extended_hotkeys/core.py
+++ b/extended_hotkeys/core.py
@@ -157,7 +157,7 @@ def make_multiple_hotkey_factory(callback_list, timeout=1000, fast_exit=True):
     return multiple_hotkey_manager
 
 
-def addExtendedCommand(menu, name, commands, shortcut=None, icon=None, tooltip=None, index=None, readonly=None, shortcutContext=None, timeout=1000):
+def addExtendedCommand(menu, name, commands, shortcut=None, icon=None, tooltip="", index=-1, readonly=False, shortcutContext=0, timeout=1000):
     """
 addExtendedCommand(...)
     self.addCommand(name, command, shortcut, icon, tooltip, index, readonly) -> The menu/toolbar item that was added to hold the command.


### PR DESCRIPTION
Update the underlying command to pass kwargs
This way we only pass non-default values

A quick note, we aren't really sure the default value for the
shortcutContext so we set it's default to None and only update it if it
is not None.


This closes #2 