### PR TITLE
First round of bugfixing

### DIFF
--- a/extended_hotkeys/core.py
+++ b/extended_hotkeys/core.py
@@ -157,7 +157,7 @@ def make_multiple_hotkey_factory(callback_list, timeout=1000, fast_exit=True):
     return multiple_hotkey_manager
 
 
-def addExtendedCommand(menu, name, commands, shortcut=None, icon=None, tooltip="", index=-1, readonly=False, shortcutContext=0, timeout=1000):
+def addExtendedCommand(menu, name, commands, shortcut=None, icon=None, tooltip="", index=-1, readonly=False, shortcutContext=None, timeout=1000):
     """
 addExtendedCommand(...)
     self.addCommand(name, command, shortcut, icon, tooltip, index, readonly) -> The menu/toolbar item that was added to hold the command.
@@ -185,14 +185,24 @@ addExtendedCommand(...)
         output_command = sanitized_commands[0]
     else:
         output_command = make_multiple_hotkey_factory(sanitized_commands, timeout=timeout)
+
+    kwargs = {}
+    if shortcut:
+        kwargs["shortcut"] = shortcut
+    if icon:
+        kwargs["icon"] = icon
+    if tooltip:
+        kwargs["tooltip"] = tooltip
+    if index != -1:
+        kwargs["index"] = index
+    if readonly is not False:
+        kwargs["readonly"] = readonly
+    if shortcutContext is not None:
+        kwargs["shortcutContext"] = shortcutContext
+
     return menu.addCommand(
         name,
         output_command,
-        shortcut=shortcut,
-        icon=icon,
-        tooltip=tooltip,
-        index=index,
-        readonly=readonly,
-        shortcutContext=shortcutContext
+        **kwargs
     )
 

--- a/extended_hotkeys/core.py
+++ b/extended_hotkeys/core.py
@@ -157,7 +157,7 @@ def make_multiple_hotkey_factory(callback_list, timeout=1000, fast_exit=True):
     return multiple_hotkey_manager
 
 
-def addExtendedCommand(menu, name, commands, shortcut=None, icon=None, tooltip=None, index=None, readonly=None, shortcutContext=None, timeout=1000):
+def addExtendedCommand(menu, name, commands, shortcut=None, icon=None, tooltip="", index=-1, readonly=False, shortcutContext=0, timeout=1000):
     """
 addExtendedCommand(...)
     self.addCommand(name, command, shortcut, icon, tooltip, index, readonly) -> The menu/toolbar item that was added to hold the command.

--- a/extended_hotkeys/core.py
+++ b/extended_hotkeys/core.py
@@ -32,15 +32,11 @@ TIMER_UNSET = -1
 
 
 def __anonymous(text):
-    py2_src = """def __():
-        exec \"{text}\"""".format(text=text)
+    src = """def __():
+        {text}""".format(text=text)
 
-    py3_src = """def __():
-    exec(\"{text}\")""".format(text=text)
-
-    if sys.version_info[0] > 2:
-        return eval(py3_src)
-    return eval(py2_src)
+    exec(src)
+    return locals()["__"]
 
 
 def __item_invoke(item):

--- a/extended_hotkeys/helpers.py
+++ b/extended_hotkeys/helpers.py
@@ -46,7 +46,7 @@ def jump_to_input(number):
     jump_to_input takes an input number and when called will center 
       your viewer on whichever node your viewer is connected to at index <number>
 
-    :param number: The 0 indexed number corresponding to the input you want
+    :param number: The 1 indexed number corresponding to the input you want
     :type number: int
     :return: A lazy function that will evaluate the input at index <index> when called.
     :rettype: types.FunctionType
@@ -56,7 +56,7 @@ def jump_to_input(number):
             node.setSelected(False)
 
         viewer = nuke.activeViewer()
-        viewer.node().input(number).setSelected(True)
+        viewer.node().input(number-1).setSelected(True)
         nuke.zoomToFitSelected()
 
     return jump_to_handler

--- a/extended_hotkeys/helpers.py
+++ b/extended_hotkeys/helpers.py
@@ -1,3 +1,5 @@
+import nuke
+import nukescripts
 VIEWER_INPUT_PROXY = "Viewer/Input/"
 
 def viewer_hotkey(number):


### PR DESCRIPTION
Bugfixes:
  - Imports were missing in extended_hotkeys.helpers.
  - The addCommand that we were calling in addExtendedCommand was passing the wrong default args.
  - The jump_to_input helper function was off by one.
  - The anonymous function factory for string functions was not compiling in python 2 or 3.