### PR TITLE
Update the default state of the key to TIMER_UNSET

### DIFF
--- a/extended_hotkeys/core.py
+++ b/extended_hotkeys/core.py
@@ -149,7 +149,7 @@ def make_multiple_hotkey_factory(callback_list, timeout=1000, fast_exit=True):
                 # Timer is set to an unknown value! Set it to UNSET and hope it doesn't get changed again.
                 __set_global_value(key, TIMER_UNSET)
                 __clear_list(callback_stack)
-
+    __set_global_value(key, TIMER_UNSET)
     return multiple_hotkey_manager
 
 


### PR DESCRIPTION
This was not being done before which is where the bug came from.
The first press was setting the global state to TIMER_UNSET and then the
next one was working correctly.